### PR TITLE
USD/EUR kodları ters yazılmış. Tekrar doğru şekilde yazıldı.

### DIFF
--- a/src/Paranoia/Payment/Adapter/AdapterAbstract.php
+++ b/src/Paranoia/Payment/Adapter/AdapterAbstract.php
@@ -35,8 +35,8 @@ abstract class AdapterAbstract
      */
     protected $currencyCodes = array(
         self::CURRENCY_TRY => 949,
-        self::CURRENCY_EUR => 840,
-        self::CURRENCY_USD => 978,
+        self::CURRENCY_EUR => 978,
+        self::CURRENCY_USD => 840,
     );
 
     /**


### PR DESCRIPTION
Bunu ödemeyi aldıktan sonra acı yoldan fark ettik :+1: 
