### PR TITLE
Update Posnet.php

### DIFF
--- a/src/Paranoia/Payment/Adapter/Posnet.php
+++ b/src/Paranoia/Payment/Adapter/Posnet.php
@@ -250,7 +250,7 @@ class Posnet extends AdapterAbstract
     protected function formatAmount($amount, $reverse = false)
     {
         if (!$reverse) {
-            return ceil($amount * 100);
+            return ceil($amount * 10*10);
         } else {
             return (float)sprintf('%s.%s', substr($amount, 0, -2), substr($amount, -2));
         }


### PR DESCRIPTION
setAmount("69.90") bankaya gönderilen değer 6991 bir kuruş fazala çekiliyor
69.90*100 = 6990.000000000001
ceil(6990.000000000001) = 6991
69.90*10*10 = 6990
neden böyle bi sonuç çıktığını bilmiyorum ama 10*10 yaptığında sonucu doğru veriyor
aynı problem 79.90 değeri içinde geçerli