### PR TITLE
Update AbstractPos.php

### DIFF
--- a/src/Pos/AbstractPos.php
+++ b/src/Pos/AbstractPos.php
@@ -61,6 +61,7 @@ abstract class AbstractPos
            'curl.options' => array(
                CURLOPT_SSL_VERIFYPEER => false,
                CURLOPT_SSL_VERIFYHOST => false,
+               CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1_2
            )
         ));
         $request = $client->post($url, null, $data);


### PR DESCRIPTION
Yapı kredi pos kullanıyorum ve artık ssl 1.0 04-12-2018 10:00 itibari ile desteklemediğini açıkladı ve işlem yapılamıyor
**CURLOPT_SSLVERSION** = (**CURL_SSLVERSION_TLSv1_2** = 6 | **CURL_SSLVERSION_TLSv1_1** = 5 | **CURL_SSLVERSION_TLSv1** =1 ) yapmak gerekiyormuş ve dışardan parametre almıyor malesef
şuan için composer update i iptal edip elle duzeltmemiz gerekti

php7.0,
OpenSSL 1.0.1e-fips 11 Feb 2013
Curl 7.19.7

iyi çalışmalar